### PR TITLE
Fix all warnings when installing with NPM (or Yarn)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
 'use strict';
 
-var through  = require('through2'),
-    toml     = require('toml'),
-    gutil    = require('gulp-util'),
-    ext      = gutil.replaceExtension;
+var through     = require('through2'),
+    toml        = require('toml'),
+    PluginError = require('plugin-error');
 
 module.exports = function(opts){
   if(opts == null){opts = {}}
@@ -12,7 +11,7 @@ module.exports = function(opts){
   if(!opts.ext){ opts.ext = ".json" }
 
   var toToml = function (file){
-    file.path = ext(file.path, opts.ext);
+    file.extname = opts.ext;
     var obj = toml.parse(file.contents.toString());
     file.contents = new Buffer(opts.to(obj), 'utf8');
     return file;
@@ -24,13 +23,13 @@ module.exports = function(opts){
       return cb();
     }
     if(file.isStream()) {
-      this.emit('error', new gutil.PluginError('gulp-toml', 'Streaming not supported'));
+      this.emit('error', new PluginError('gulp-toml', 'Streaming not supported'));
       return cb();
     }
     try {
       this.push(toToml(file));
     } catch(error) {
-      this.emit('error', new gutil.PluginError('gulp-toml', error.message, {'error': error}));
+      this.emit('error', new PluginError('gulp-toml', error.message, {'error': error}));
     }
     return cb();
   });

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "url": "https://github.com/will-ob/gulp-toml/issues"
   },
   "dependencies": {
-    "gulp-util": "~3.0.8",
-    "toml": "~2.3.0",
-    "through2": "~0.4.1"
+    "plugin-error": "^1.0.1",
+    "through2": "~2.0.3",
+    "toml": "~2.3.3"
   },
   "devDependencies": {
-    "mocha": "~1.18.2",
-    "assert": "~1.1.1",
-    "gulp-util": "~3.0.8"
+    "assert": "~1.4.1",
+    "mocha": "~5.2.0",
+    "vinyl": "^2.2.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,10 @@
 'use strict';
 
 var assert = require('assert'),
-    gutil  = require('gulp-util'),
+    File   = require('vinyl'),
     gtoml  = require('../index'),
-    fs     = require('fs');
+    fs     = require('fs'),
+    path   = require('path');;
 
 it('should jsonify the toml', function (cb) {
 
@@ -14,12 +15,12 @@ it('should jsonify the toml', function (cb) {
 
   stream.on('data', function (file) {
     assert.equal(file.relative, 'example.json');
-    assert.equal(file.path, 'test/fixture/example.json');
+    assert.equal(file.path, path.normalize('test/fixture/example.json'));
     assert.equal(file.contents.toString().trim(), fs.readFileSync('./test/fixture/example.json', 'utf8').trim());
     cb();
   });
 
-  stream.write(new gutil.File({
+  stream.write(new File({
     cwd: './test',
     base: './test/fixture',
     path: './test/fixture/example.toml',
@@ -47,7 +48,7 @@ it('should include error details', function (cb) {
     cb();
   })
 
-  stream.write(new gutil.File({
+  stream.write(new File({
     cwd: './test',
     base: './test/fixture',
     path: './test/fixture/error.toml',


### PR DESCRIPTION
* [**Remove gulp-util dependency**](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5) as the module has been deprecated for decades and causes the warnings
* **Update the other dependencies**, because it's good
* **Fix tests on Windows**, because Windows uses backslashes in paths and the tests did not work with that

Thanks thanks, remember to drink a lot of milk to keep your bones healthy